### PR TITLE
Fix schedule time range parsing

### DIFF
--- a/src/test_parse_times.py
+++ b/src/test_parse_times.py
@@ -1,0 +1,17 @@
+import utils
+
+def test_parse_time_string_range():
+    result = utils.parse_time_string('13-16, 18')
+    assert result == [
+        {'hour': 13},
+        {'hour': 14},
+        {'hour': 15},
+        {'hour': 16},
+        {'hour': 18},
+    ]
+
+def test_parse_time_string_invalid():
+    result = utils.parse_time_string('25, -1, a, 5-3')
+    # Should ignore invalid entries and return empty list except valid numbers
+    assert result == []
+

--- a/src/ui_config_window.py
+++ b/src/ui_config_window.py
@@ -2,6 +2,7 @@ import tkinter as tk
 from tkinter import ttk, messagebox, Toplevel
 import re
 import logging
+import utils
 
 # Placeholder for ConfigManager if needed directly (passed in constructor)
 # from config_manager import ConfigManager
@@ -310,30 +311,9 @@ class ConfigWindow(Toplevel):
          except Exception as e: logging.exception(f"Error updating treeview item {index}: {e}")
 
     def parse_times(self):
-        time_str = self.time_entry.get().strip(); times_list = []
-        if not time_str: return times_list
-        for part in time_str.split(','):
-            part = part.strip();
-            if not part: continue
-            range_match = re.match(r'^(\d{1,2})-(\d{1,2})$', part)
-            if range_match:
-                try:
-                    start, end = int(range_match.group(1)), int(range_match.group(2))
-                    if 0 <= start <= 23 and 0 <= end <= 23 and start <= end:
-                        for hour in range(start, end + 1):
-                            time_obj = {"hour": hour}
-                            if time_obj not in times_list: times_list.append(time_obj)
-                    else: logging.warning(f"Invalid hour range: {part}")
-                except ValueError: logging.warning(f"Invalid number in range: {part}")
-            else:
-                try:
-                    hour = int(part)
-                    if 0 <= hour <= 23:
-                         time_obj = {"hour": hour}
-                         if time_obj not in times_list: times_list.append(time_obj)
-                    else: logging.warning(f"Invalid hour: {part}")
-                except ValueError: logging.warning(f"Invalid time format: {part}")
-        times_list.sort(key=lambda x: x['hour']); return times_list
+        """Parse the hours from the entry widget using ``utils.parse_time_string``."""
+        time_str = self.time_entry.get().strip()
+        return utils.parse_time_string(time_str)
 
     def on_message_select(self, event):
         selected_items = self.tree.selection()

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,5 +1,53 @@
 import logging
 from datetime import datetime
+import re
+
+def parse_time_string(time_str: str):
+    """Parse a comma separated string of hours and hour ranges.
+
+    Args:
+        time_str: String like ``"9, 13-15, 20"``.
+
+    Returns:
+        List of dicts in the form ``{"hour": int}`` sorted by hour.
+    """
+    times_list = []
+    if not time_str:
+        return times_list
+
+    for part in time_str.split(','):
+        part = part.strip()
+        if not part:
+            continue
+
+        range_match = re.match(r'^(\d{1,2})-(\d{1,2})$', part)
+        if range_match:
+            try:
+                start = int(range_match.group(1))
+                end = int(range_match.group(2))
+                if 0 <= start <= 23 and 0 <= end <= 23 and start <= end:
+                    for hour in range(start, end + 1):
+                        time_obj = {"hour": hour}
+                        if time_obj not in times_list:
+                            times_list.append(time_obj)
+                else:
+                    logging.warning(f"Invalid hour range: {part}")
+            except ValueError:
+                logging.warning(f"Invalid number in range: {part}")
+        else:
+            try:
+                hour = int(part)
+                if 0 <= hour <= 23:
+                    time_obj = {"hour": hour}
+                    if time_obj not in times_list:
+                        times_list.append(time_obj)
+                else:
+                    logging.warning(f"Invalid hour: {part}")
+            except ValueError:
+                logging.warning(f"Invalid time format: {part}")
+
+    times_list.sort(key=lambda x: x['hour'])
+    return times_list
 
 # Example utility function (though logging handles formatting now)
 # def format_timestamp(dt_object=None):


### PR DESCRIPTION
## Summary
- move time parsing logic into `utils.parse_time_string`
- use the new helper in `ConfigWindow.parse_times`
- add tests covering range parsing and invalid values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c4925c8d48325b9fea131655267db