### PR TITLE
Add hourly ad service with lecture-aware scheduling

### DIFF
--- a/src/hourly_ad_service.py
+++ b/src/hourly_ad_service.py
@@ -1,0 +1,78 @@
+import logging
+import time
+from datetime import datetime
+
+from ad_inserter_service import AdInserterService
+from lecture_detector import LectureDetector
+
+logger = logging.getLogger('HourlyAds')
+
+class HourlyAdService:
+    """Service that triggers ads once every hour based on lecture schedule."""
+
+    def __init__(self, config_manager):
+        self.config_manager = config_manager
+        self.running = False
+        self.flag_run_on_next_track = False
+        self.last_track_signature = None
+
+        now_playing_xml = self.config_manager.get_setting(
+            "settings.rds.now_playing_xml", r"G:\\To_RDS\\nowplaying.xml"
+        )
+        self.lecture_detector = LectureDetector(
+            xml_path=now_playing_xml, config_manager=config_manager
+        )
+        self.ad_service = AdInserterService(config_manager)
+
+    def run(self):
+        """Main loop that checks every second for hourly triggers and track changes."""
+        logger.info("HourlyAdService started")
+        self.running = True
+        last_hour_handled = None
+        while self.running:
+            now = datetime.now()
+            if now.minute == 0 and now.hour != last_hour_handled:
+                self._handle_top_of_hour(now)
+                last_hour_handled = now.hour
+
+            if self.flag_run_on_next_track:
+                self._check_for_track_change()
+
+            time.sleep(1)
+
+    def stop(self):  # pragma: no cover - graceful shutdown hook
+        self.running = False
+
+    # --- Internal helpers -------------------------------------------------
+    def _handle_top_of_hour(self, now):
+        logger.info("Top-of-hour ad check")
+        try:
+            if self.lecture_detector.is_next_track_lecture():
+                logger.info("Next track is lecture - scheduling ads")
+                self.ad_service.run()
+                return
+
+            if self.lecture_detector.next_lecture_starts_within_hour(now):
+                logger.info(
+                    "Next track not lecture but lecture within hour - will schedule on next track start"
+                )
+                self.flag_run_on_next_track = True
+                info = self.lecture_detector.get_current_track_info()
+                self.last_track_signature = (info.get('artist', ''), info.get('title', ''))
+            else:
+                logger.info("No lecture within next hour - playing ads instantly")
+                self.ad_service.run_instant()
+        except Exception as e:  # pragma: no cover - runtime safety
+            logger.exception(f"Hourly ad check failed: {e}")
+
+    def _check_for_track_change(self):
+        info = self.lecture_detector.get_current_track_info()
+        signature = (info.get('artist', ''), info.get('title', ''))
+        if self.last_track_signature is None:
+            self.last_track_signature = signature
+            return
+        if signature != self.last_track_signature:
+            logger.info("Detected new track - scheduling ads")
+            self.ad_service.run()
+            self.flag_run_on_next_track = False
+            self.last_track_signature = signature

--- a/src/test_lecture_detector_timing.py
+++ b/src/test_lecture_detector_timing.py
@@ -1,0 +1,36 @@
+import textwrap
+from datetime import datetime
+
+from lecture_detector import LectureDetector
+
+
+def _write_xml(tmp_path, start_time, duration):
+    content = textwrap.dedent(f"""
+    <ROOT>
+        <TRACK ARTIST="A">
+            <DURATION>00:05</DURATION>
+        </TRACK>
+        <NEXTTRACK>
+            <TRACK ARTIST="B" STARTTIME="{start_time}">
+                <DURATION>{duration}</DURATION>
+            </TRACK>
+        </NEXTTRACK>
+    </ROOT>
+    """)
+    xml_file = tmp_path / "np.xml"
+    xml_file.write_text(content)
+    return xml_file
+
+
+def test_next_lecture_within_hour_true(tmp_path):
+    xml_file = _write_xml(tmp_path, "14:10:00", "20:00")
+    detector = LectureDetector(str(xml_file))
+    now = datetime(2024, 1, 1, 14, 0, 0)
+    assert detector.next_lecture_starts_within_hour(now) is True
+
+
+def test_next_lecture_within_hour_false(tmp_path):
+    xml_file = _write_xml(tmp_path, "14:40:00", "30:00")
+    detector = LectureDetector(str(xml_file))
+    now = datetime(2024, 1, 1, 14, 0, 0)
+    assert detector.next_lecture_starts_within_hour(now) is False


### PR DESCRIPTION
## Summary
- add `HourlyAdService` that triggers scheduled or instant ads based on upcoming lectures
- extend `LectureDetector` with timing utilities to predict when the next lecture starts
- integrate hourly ad runner and log pane into main application UI

## Testing
- `pytest src/test_lecture_detector_timing.py src/test_ad_inserter_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68a899ae6d508325834e872a369604ae