### PR TITLE
Add hourly ad service with lecture-aware scheduling

### DIFF
--- a/src/hourly_ad_service.py
+++ b/src/hourly_ad_service.py
@@ -1,0 +1,78 @@
+import logging
+import time
+from datetime import datetime
+
+from ad_inserter_service import AdInserterService
+from lecture_detector import LectureDetector
+
+logger = logging.getLogger('HourlyAds')
+
+class HourlyAdService:
+    """Service that triggers ads once every hour based on lecture schedule."""
+
+    def __init__(self, config_manager):
+        self.config_manager = config_manager
+        self.running = False
+        self.flag_run_on_next_track = False
+        self.last_track_signature = None
+
+        now_playing_xml = self.config_manager.get_setting(
+            "settings.rds.now_playing_xml", r"G:\\To_RDS\\nowplaying.xml"
+        )
+        self.lecture_detector = LectureDetector(
+            xml_path=now_playing_xml, config_manager=config_manager
+        )
+        self.ad_service = AdInserterService(config_manager)
+
+    def run(self):
+        """Main loop that checks every second for hourly triggers and track changes."""
+        logger.info("HourlyAdService started")
+        self.running = True
+        last_hour_handled = None
+        while self.running:
+            now = datetime.now()
+            if now.minute == 0 and now.hour != last_hour_handled:
+                self._handle_top_of_hour(now)
+                last_hour_handled = now.hour
+
+            if self.flag_run_on_next_track:
+                self._check_for_track_change()
+
+            time.sleep(1)
+
+    def stop(self):  # pragma: no cover - graceful shutdown hook
+        self.running = False
+
+    # --- Internal helpers -------------------------------------------------
+    def _handle_top_of_hour(self, now):
+        logger.info("Top-of-hour ad check")
+        try:
+            if self.lecture_detector.is_next_track_lecture():
+                logger.info("Next track is lecture - scheduling ads")
+                self.ad_service.run()
+                return
+
+            if self.lecture_detector.next_lecture_starts_within_hour(now):
+                logger.info(
+                    "Next track not lecture but lecture within hour - will schedule on next track start"
+                )
+                self.flag_run_on_next_track = True
+                info = self.lecture_detector.get_current_track_info()
+                self.last_track_signature = (info.get('artist', ''), info.get('title', ''))
+            else:
+                logger.info("No lecture within next hour - playing ads instantly")
+                self.ad_service.run_instant()
+        except Exception as e:  # pragma: no cover - runtime safety
+            logger.exception(f"Hourly ad check failed: {e}")
+
+    def _check_for_track_change(self):
+        info = self.lecture_detector.get_current_track_info()
+        signature = (info.get('artist', ''), info.get('title', ''))
+        if self.last_track_signature is None:
+            self.last_track_signature = signature
+            return
+        if signature != self.last_track_signature:
+            logger.info("Detected new track - scheduling ads")
+            self.ad_service.run()
+            self.flag_run_on_next_track = False
+            self.last_track_signature = signature

--- a/src/test_ad_inserter_service.py
+++ b/src/test_ad_inserter_service.py
@@ -45,3 +45,40 @@ def test_combine_ads_respects_schedule(monkeypatch):
 
     assert service._combine_ads() is True
     assert captured["files"] == ["a.mp3", "c.mp3"]
+
+
+def test_combine_ads_handles_string_flags(monkeypatch):
+    ads = [
+        {
+            "Enabled": "True",
+            "Scheduled": "True",
+            "Days": ["Monday"],
+            "Times": [{"hour": 10}],
+            "MP3File": "a.mp3",
+        },
+        {"Enabled": "True", "Scheduled": "False", "MP3File": "b.mp3"},
+        {"Enabled": "False", "Scheduled": "False", "MP3File": "c.mp3"},
+    ]
+    config = DummyConfigManager(ads)
+    service = AdInserterService(config)
+
+    class FixedDateTime:
+        @classmethod
+        def now(cls):
+            from datetime import datetime as _dt
+            return _dt(2024, 8, 5, 10, 0, 0)  # Monday 10 AM
+
+    monkeypatch.setattr(ad_inserter_service, "datetime", FixedDateTime)
+    monkeypatch.setattr(os.path, "exists", lambda p: True)
+    monkeypatch.setattr(os, "makedirs", lambda *args, **kwargs: None)
+
+    captured = {}
+
+    def fake_concat(self, files, output):
+        captured["files"] = files
+        return True
+
+    monkeypatch.setattr(AdInserterService, "_concatenate_mp3_files", fake_concat)
+
+    assert service._combine_ads() is True
+    assert captured["files"] == ["a.mp3", "b.mp3"]

--- a/src/test_lecture_detector_timing.py
+++ b/src/test_lecture_detector_timing.py
@@ -1,0 +1,38 @@
+import textwrap
+from datetime import datetime
+
+from lecture_detector import LectureDetector
+
+
+def _write_xml(tmp_path, started, cur_dur, next_dur):
+    content = textwrap.dedent(
+        f"""
+        <PLAYER>
+            <TRACK ARTIST="A" STARTED="{started}" DURATION="{cur_dur}" />
+            <NEXTTRACK>
+                <TRACK ARTIST="B" DURATION="{next_dur}" />
+            </NEXTTRACK>
+        </PLAYER>
+        """
+    )
+    xml_file = tmp_path / "np.xml"
+    xml_file.write_text(content)
+    return xml_file
+
+
+def test_next_lecture_within_hour_true(tmp_path):
+    xml_file = _write_xml(
+        tmp_path, "2024-01-01 14:00:00", "00:10:00", "00:20:00"
+    )
+    detector = LectureDetector(str(xml_file))
+    now = datetime(2024, 1, 1, 14, 0, 0)
+    assert detector.next_lecture_starts_within_hour(now) is True
+
+
+def test_next_lecture_within_hour_false(tmp_path):
+    xml_file = _write_xml(
+        tmp_path, "2024-01-01 14:00:00", "00:40:00", "00:30:00"
+    )
+    detector = LectureDetector(str(xml_file))
+    now = datetime(2024, 1, 1, 14, 0, 0)
+    assert detector.next_lecture_starts_within_hour(now) is False

--- a/src/ui_options_window.py
+++ b/src/ui_options_window.py
@@ -2,8 +2,10 @@
 import tkinter as tk
 from tkinter import ttk, messagebox, Toplevel, filedialog
 import logging
+from datetime import datetime
 
 from ad_inserter_service import AdInserterService
+from hourly_ad_service import HourlyAdService
 
 # Placeholders for managers/handlers if needed directly (passed in constructor)
 # from config_manager import ConfigManager
@@ -91,6 +93,20 @@ class OptionsWindow(Toplevel):
             wraplength=380,
         )
         instant_help.pack(pady=2)
+
+        # Button to simulate top-of-hour hourly ad check
+        hourly_button = ttk.Button(
+            debug_frame,
+            text="Simulate Hour Start",
+            command=self.simulate_hour_start_action,
+        )
+        hourly_button.pack(pady=5)
+        hourly_help = ttk.Label(
+            debug_frame,
+            text="Trigger hourly ad check as if a new hour began.",
+            wraplength=380,
+        )
+        hourly_help.pack(pady=2)
 
         # --- Settings Tab (New) ---
         settings_frame = ttk.Frame(notebook, padding="10")
@@ -296,6 +312,16 @@ class OptionsWindow(Toplevel):
                 logging.error("Instant ad failed via Options window. Check logs.")
         except Exception:
             logging.exception("Exception running AdInserterService instant.")
+
+    def simulate_hour_start_action(self):
+        """Simulate top-of-hour check for the hourly ad service."""
+        logging.debug("Simulate Hour Start button clicked.")
+        try:
+            service = HourlyAdService(self.config_manager)
+            service._handle_top_of_hour(datetime.now())
+            logging.info("Hourly ad check simulated via Options window.")
+        except Exception:
+            logging.exception("Exception simulating HourlyAdService top-of-hour.")
 
     def save_and_close(self):
         """Saves the whitelist/blacklist if changed and closes."""


### PR DESCRIPTION
## Summary
- add `HourlyAdService` that triggers scheduled or instant ads based on upcoming lectures
- extend `LectureDetector` with timing utilities to parse RadioBOSS XML timestamps and durations
- integrate hourly ad runner and log pane into main application UI

## Testing
- `pytest -q src/test_lecture_detector_timing.py src/test_ad_inserter_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68a899ae6d508325834e872a369604ae