### PR TITLE
Fix ad scheduling when next track repeats

### DIFF
--- a/src/hourly_ad_service.py
+++ b/src/hourly_ad_service.py
@@ -58,7 +58,12 @@ class HourlyAdService:
                 )
                 self.flag_run_on_next_track = True
                 info = self.lecture_detector.get_current_track_info()
-                self.last_track_signature = (info.get('artist', ''), info.get('title', ''))
+                started = self.lecture_detector.get_current_track_started()
+                self.last_track_signature = (
+                    info.get('artist', ''),
+                    info.get('title', ''),
+                    started,
+                )
             else:
                 logger.info("No lecture within next hour - playing ads instantly")
                 self.ad_service.run_instant()
@@ -67,7 +72,8 @@ class HourlyAdService:
 
     def _check_for_track_change(self):
         info = self.lecture_detector.get_current_track_info()
-        signature = (info.get('artist', ''), info.get('title', ''))
+        started = self.lecture_detector.get_current_track_started()
+        signature = (info.get('artist', ''), info.get('title', ''), started)
         if self.last_track_signature is None:
             self.last_track_signature = signature
             return

--- a/src/lecture_detector.py
+++ b/src/lecture_detector.py
@@ -159,6 +159,26 @@ class LectureDetector:
             logging.exception(f"Error getting current track info: {e}")
             return {"artist": "", "title": ""}
 
+    def get_current_track_started(self):
+        """Returns the ``STARTED`` timestamp of the current track."""
+        try:
+            if not os.path.exists(self.xml_path):
+                return ""
+
+            tree = ET.parse(self.xml_path)
+            root = tree.getroot()
+            current_track = root.find("TRACK")
+            if current_track is not None:
+                return current_track.get("STARTED", "").strip()
+            return ""
+
+        except ET.ParseError as e:
+            logging.error(f"Error parsing XML file ({self.xml_path}): {e}")
+            return ""
+        except Exception as e:
+            logging.exception(f"Error getting current track started: {e}")
+            return ""
+
     def get_current_track_duration(self):
         """Returns the duration of the current track from the XML file.
         

--- a/src/test_hourly_ad_service.py
+++ b/src/test_hourly_ad_service.py
@@ -1,0 +1,35 @@
+from unittest.mock import Mock
+
+from hourly_ad_service import HourlyAdService
+
+
+class DummyConfig:
+    def get_setting(self, key, default=None):
+        return default
+
+    def get_blacklist(self):
+        return []
+
+    def get_whitelist(self):
+        return []
+
+
+def test_ads_run_when_track_started_changes():
+    service = HourlyAdService(DummyConfig())
+    service.flag_run_on_next_track = True
+    # Mock lecture detector to return same artist/title but different STARTED times
+    detector = Mock()
+    service.lecture_detector = detector
+    # initial signature
+    detector.get_current_track_info.return_value = {"artist": "A", "title": "Song"}
+    detector.get_current_track_started.return_value = "2024-01-01 12:00:00"
+    service.last_track_signature = ("A", "Song", "2024-01-01 12:00:00")
+
+    # Next call simulates same song replayed but new start time
+    detector.get_current_track_info.return_value = {"artist": "A", "title": "Song"}
+    detector.get_current_track_started.return_value = "2024-01-01 12:03:00"
+
+    service.ad_service = Mock()
+    service._check_for_track_change()
+    service.ad_service.run.assert_called_once()
+    assert service.flag_run_on_next_track is False


### PR DESCRIPTION
## Summary
- detect track changes using STARTED timestamp so ads schedule even when artist/title repeat
- expose track start time from LectureDetector
- test hourly ad service for repeated tracks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab7fa4d9cc83259bb8d6164e515a7c